### PR TITLE
PyPi metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,11 @@
 [tool.poetry]
 name = "xmen"
 version = "0.1.0"
-description = ""
+description = "An extensible toolkit for Cross-lingual (x) Medical Entity Normalization."
+license = "Apache-2.0"
 authors = ["Florian Borchert <florian.borchert@hpi.de>"]
+readme = "README.md"
+repository = "https://github.com/hpi-dhc/xmen"
 
 [tool.poetry.scripts]
 xmen = "xmen.cli.cli:main"


### PR DESCRIPTION
In theory, this should suffice. You should just build the wheel `poetry build` and publish it `poetry publish --username xxx --password  yyy` as usual and the info should be updated in https://pypi.org/project/xmen/. 

I am not sure the `README.md` is going to look perfect, there are some [PyPI-friendly README guidelines](https://packaging.python.org/en/latest/guides/making-a-pypi-friendly-readme/). If it does not look nice, I can see to touch up the one you made or just make a new one for PyPi separate from the github one (that'd mean two docs to maintain, though).

We can also populate these optional fields if you want something in: maintainers, homepage, documentation and keywords.