### PR TITLE
Prediction for strings without context

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "xmen"
-version = "1.0.4"
+version = "1.0.5"
 description = "An extensible toolkit for Cross-lingual (x) Medical Entity Normalization."
 license = "Apache-2.0"
 authors = ["Florian Borchert <florian.borchert@hpi.de>"]


### PR DESCRIPTION
all linkers have a new method `predict_no_context` to feed strings or list of strings into a candidate generator.

fixes #28